### PR TITLE
Add XcodePlugin support

### DIFF
--- a/Plugins/SwiftGenPlugin/Plugin.swift
+++ b/Plugins/SwiftGenPlugin/Plugin.swift
@@ -31,6 +31,33 @@ struct SwiftGenPlugin: BuildToolPlugin {
   }
 }
 
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension SwiftGenPlugin: XcodeBuildToolPlugin {
+  func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
+    let fileManager = FileManager.default
+
+    // Possible paths where there may be a config file (root of package, target dir.)
+    let configurations: [Path] = [context.xcodeProject.directory]
+      .map { $0.appending("swiftgen.yml") }
+      .filter { fileManager.fileExists(atPath: $0.string) }
+
+    // Validate paths list
+    guard validate(configurations: configurations, target: target) else {
+      return []
+    }
+
+    // Clear the SwiftGen plugin's directory (in case of dangling files)
+    fileManager.forceClean(directory: context.pluginWorkDirectory)
+
+    return try configurations.map { configuration in
+      try .swiftgen(using: configuration, context: context, target: target)
+    }
+  }
+}
+#endif
+
 // MARK: - Helpers
 
 private extension SwiftGenPlugin {
@@ -47,6 +74,21 @@ private extension SwiftGenPlugin {
 
     return true
   }
+
+#if canImport(XcodeProjectPlugin)
+  func validate(configurations: [Path], target: XcodeTarget) -> Bool {
+    guard !configurations.isEmpty else {
+      Diagnostics.error("""
+        No SwiftGen configurations found for target \(target.displayName). If you would like to generate sources for this \
+        target include a `swiftgen.yml` in the target's source directory, or include a shared `swiftgen.yml` at the \
+        package's root.
+        """)
+      return false
+    }
+
+    return true
+  }
+#endif
 }
 
 private extension Command {
@@ -69,6 +111,27 @@ private extension Command {
       outputFilesDirectory: context.pluginWorkDirectory
     )
   }
+
+#if canImport(XcodeProjectPlugin)
+  static func swiftgen(using configuration: Path, context: XcodePluginContext, target: XcodeTarget) throws -> Command {
+    .prebuildCommand(
+      displayName: "SwiftGen BuildTool Plugin",
+      executable: try context.tool(named: "swiftgen").path,
+      arguments: [
+        "config",
+        "run",
+        "--verbose",
+        "--config", "\(configuration)"
+      ],
+      environment: [
+        "PROJECT_DIR": context.xcodeProject.directory,
+        "TARGET_NAME": target.displayName,
+        "DERIVED_SOURCES_DIR": context.pluginWorkDirectory
+      ],
+      outputFilesDirectory: context.pluginWorkDirectory
+    )
+  }
+#endif
 }
 
 private extension FileManager {


### PR DESCRIPTION
Replicating upstream SwiftGen/SwiftGenPlugin#4 in our fork until it gets merged 🕯️

This will allow us to have a git tag which then produces a "stable" version so SPM doesn't complain with:

```
Dependencies could not be resolved because '<x>' depends on '<y>' 0.1.0..<0.2.0.
'<x>' >= 0.1.0 cannot be used because package '<y>' is required using a stable-version but '<y>' depends on an unstable-version package 'swiftgenplugin' and no versions of '<y>' match the requirement 0.1.1..<0.2.0.
```
